### PR TITLE
fix(cal_center_bbox): Replace np.bool with bool

### DIFF
--- a/neural_network/cal_center_bbox.py
+++ b/neural_network/cal_center_bbox.py
@@ -221,7 +221,7 @@ def get_center_bbox(scene_idx, camera='realsense'):
                 cv2.circle(rgb_image, (center_x, center_y), 10, (255,0,0), -1)
 
         bbox_single = np.concatenate(bbox_list_single, axis=0)[np.newaxis, :, :]                
-        mask_single = np.array(mask_list_single, dtype=np.bool)[np.newaxis, :]
+        mask_single = np.array(mask_list_single, dtype=bool)[np.newaxis, :]
         bbox_list_scene.append(bbox_single)
         mask_list_scene.append(mask_single)
         # print('concatenate:', np.concatenate(center_list_single, axis=0).shape)


### PR DESCRIPTION
`np.bool` was deprecated in NumPy 1.20.
Please see an output below:

> AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:

So I replaced `np.bool` with `bool` according to official guidelines.
